### PR TITLE
Fix the warning: Return type of As247\WpEloquent\Container\Container:…

### DIFF
--- a/src/Container/RewindableGenerator.php
+++ b/src/Container/RewindableGenerator.php
@@ -49,6 +49,7 @@ class RewindableGenerator implements Countable, IteratorAggregate
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         if (is_callable($count = $this->count)) {

--- a/src/Database/Eloquent/Model.php
+++ b/src/Database/Eloquent/Model.php
@@ -1189,6 +1189,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -213,6 +213,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Pagination/Paginator.php
+++ b/src/Pagination/Paginator.php
@@ -158,6 +158,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -1306,6 +1306,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);

--- a/src/Support/Fluent.php
+++ b/src/Support/Fluent.php
@@ -70,6 +70,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Support/LazyCollection.php
+++ b/src/Support/LazyCollection.php
@@ -1344,6 +1344,7 @@ class LazyCollection implements Enumerable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         if (is_array($this->source)) {

--- a/src/Support/Traits/EnumeratesValues.php
+++ b/src/Support/Traits/EnumeratesValues.php
@@ -789,6 +789,7 @@ trait EnumeratesValues
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_map(function ($value) {


### PR DESCRIPTION
…:offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice