### PR TITLE
Fix the warning: Return type of As247\WpEloquent\Container\Container:…

### DIFF
--- a/src/Container/RewindableGenerator.php
+++ b/src/Container/RewindableGenerator.php
@@ -39,6 +39,7 @@ class RewindableGenerator implements Countable, IteratorAggregate
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return ($this->generator)();

--- a/src/Database/WpPdo.php
+++ b/src/Database/WpPdo.php
@@ -24,7 +24,12 @@ class WpPdo extends PDO
         $this->db = $wpdb;
     }
 
-
+    /**
+     * @return bool|int
+     * @throws \Exception
+     *
+     */
+    #[\ReturnTypeWillChange]
     public function beginTransaction()
     {
         if ($this->in_transaction) {
@@ -33,7 +38,7 @@ class WpPdo extends PDO
         $this->in_transaction = true;
         return $this->exec('START TRANSACTION');
     }
-
+    #[\ReturnTypeWillChange]
     public function commit()
     {
         if (!$this->in_transaction) {
@@ -42,7 +47,7 @@ class WpPdo extends PDO
         $this->in_transaction = false;
         return $this->exec('COMMIT');
     }
-
+    #[\ReturnTypeWillChange]
     public function rollBack()
     {
         if (!$this->in_transaction) {
@@ -51,12 +56,12 @@ class WpPdo extends PDO
         $this->in_transaction = false;
         return $this->exec('ROLLBACK');
     }
-
+    #[\ReturnTypeWillChange]
     public function inTransaction()
     {
         return $this->in_transaction;
     }
-
+    #[\ReturnTypeWillChange]
     public function exec($statement)
     {
         $error = $this->db->suppress_errors();
@@ -68,6 +73,7 @@ class WpPdo extends PDO
         return $result;
     }
 
+    #[\ReturnTypeWillChange]
     function query($query, $pM = null, $pA = null, $pC = null, ...$args)
     {
         $statement = $this->prepare($query);
@@ -78,6 +84,7 @@ class WpPdo extends PDO
         return $statement;
     }
 
+    #[\ReturnTypeWillChange]
     public function prepare($query, $options = null)
     {
         $statement = new WpPdoStatement($this);

--- a/src/Database/WpPdoStatement.php
+++ b/src/Database/WpPdoStatement.php
@@ -19,7 +19,7 @@ class WpPdoStatement extends \PDOStatement
     {
         $this->pdo = $pdo;
     }
-
+    #[\ReturnTypeWillChange]
     function execute($params = null)
     {
         if ($this->executed) {
@@ -36,7 +36,7 @@ class WpPdoStatement extends \PDOStatement
         $this->executed = true;
         return true;
     }
-
+    #[\ReturnTypeWillChange]
     function setFetchMode($mode, $p1 = null, $p2 = null, ...$params8)
     {
         $this->defaultFetchMode = func_get_args();
@@ -89,7 +89,7 @@ class WpPdoStatement extends \PDOStatement
 
         }
     }
-
+    #[\ReturnTypeWillChange]
     function fetch($mode = PDO::FETCH_BOTH, $cursorOrientation = PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         if (func_num_args() === 0) {
@@ -123,35 +123,35 @@ class WpPdoStatement extends \PDOStatement
         return $this->proccessRowForMode($row, $mode);
 
     }
-
+    #[\ReturnTypeWillChange]
     function fetchAll($mode = null, $map = NULL, $ctor_args = NULL, ...$args8)
     {
         return array_map(function ($row) use ($mode, $map, $ctor_args) {
             return $this->proccessRowForMode($row, $mode, $map, $ctor_args);
         }, $this->result);
     }
-
+    #[\ReturnTypeWillChange]
     function fetchObject($class = "stdClass", $constructorArgs = [])
     {
         return $this->proccessRowForMode($this->fetch(PDO::FETCH_OBJ), PDO::FETCH_CLASS, $class, $constructorArgs);
     }
-
+    #[\ReturnTypeWillChange]
     function fetchColumn($column = 0)
     {
         $row = $this->fetch(PDO::FETCH_NUM);
         return $row[$column] ?? false;
     }
-
+    #[\ReturnTypeWillChange]
     function rowCount()
     {
         return $this->resultCount;
     }
-
+    #[\ReturnTypeWillChange]
     function columnCount()
     {
         return $this->columnCount;
     }
-
+    #[\ReturnTypeWillChange]
     public function closeCursor()
     {
         $this->executed = false;
@@ -159,7 +159,7 @@ class WpPdoStatement extends \PDOStatement
         return true;
     }
 
-
+    #[\ReturnTypeWillChange]
     function bindParam($param, &$var, $type = NULL, $maxLength = NULL, $driverOptions = NULL)
     {
         $this->bindingParams[$param] = [
@@ -167,7 +167,7 @@ class WpPdoStatement extends \PDOStatement
         ];
         return true;
     }
-
+    #[\ReturnTypeWillChange]
     public function bindValue($param, $value, $type = null)
     {
         //Simple param convert

--- a/src/Pagination/AbstractPaginator.php
+++ b/src/Pagination/AbstractPaginator.php
@@ -603,6 +603,7 @@ abstract class AbstractPaginator implements Htmlable
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->items->getIterator();

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -1296,6 +1296,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->items);

--- a/src/Support/LazyCollection.php
+++ b/src/Support/LazyCollection.php
@@ -1334,6 +1334,7 @@ class LazyCollection implements Enumerable
      *
      * @return \Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->makeIterator($this->source);


### PR DESCRIPTION
…:offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice