### PR TITLE
Fix the warning: Return type of As247\WpEloquent\Container\Container:…

### DIFF
--- a/src/Database/WpPdo.php
+++ b/src/Database/WpPdo.php
@@ -91,7 +91,7 @@ class WpPdo extends PDO
         $statement->sqlQueryString = $query;
         return $statement;
     }
-
+    #[\ReturnTypeWillChange]
     public function lastInsertId($name = null)
     {
         return $this->db->insert_id;


### PR DESCRIPTION
…:offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice